### PR TITLE
Create .npmignore to ensure tests/examples don't bloat install

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+examples
+test


### PR DESCRIPTION
As discussed in #3, this mechanism prevents patterns of files from being included when people install from npm.

See https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package.
